### PR TITLE
fix:The input method cannot be switched through this plug-in on Windows.

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -65,10 +65,10 @@ export default class VimImPlugin extends Plugin {
 
 				if (editor) {
 					// check if not in insert mode(normal or visual mode), swith to normal at first
-					if (!editor.state.vim.insertMode) {
+					if (!editor.cm.cm.state.vim.insertMode) {
 						this.switchToNormal();
 					}
-					editor.on('vim-mode-change', (modeObj: any) => {
+					editor.cm.cm.on('vim-mode-change', (modeObj: any) => {
 						if (modeObj) {
 							// when editor is ready, set default mode to normal
 							this.onVimModeChanged(modeObj);


### PR DESCRIPTION

Hello, when using the vim-im-select-obsidian plugin on the Windows platform (win11 22H2), version 0.1.3, I encountered an issue where the plugin wasn't functioning properly. After inspecting it through dev-tools, I confirmed that it was due to a change in the content of the 'editor' variable. I made the following modifications to the code, and now it works fine in my Obsidian (v1.5.3).

Some error shown:
![1705403043710]（https://github.com/ALONELUR/vim-im-select-obsidian/assets/108873506/204a2f11-c7c3-4a66-a58a-ff2ce38d59ef）
![1705403158808](https://github.com/ALONELUR/vim-im-select-obsidian/assets/108873506/20ad3374-c5d6-480a-8079-d06469950239)
These two error messages correspond to the following code snippets:
![1705403271673](https://github.com/ALONELUR/vim-im-select-obsidian/assets/108873506/7f0ab730-705e-4129-80b2-2f94ece14569)

